### PR TITLE
Fix ParseLoginController for customizable fields

### DIFF
--- a/Code/Controllers/ViewController.m
+++ b/Code/Controllers/ViewController.m
@@ -31,9 +31,9 @@
 
 @implementation ViewController
 
-- (void)viewDidAppear:(BOOL)animated
+- (void)viewWillAppear:(BOOL)animated
 {
-    [super viewDidAppear:animated];
+    [super viewWillAppear:animated];
     
     if (![PFUser currentUser]) { // No user logged in
         // Create the log in view controller
@@ -61,7 +61,14 @@
         UIImageView *signupImageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"LayerParseLogin"]];
         signupImageView.contentMode = UIViewContentModeScaleAspectFit;
         signUpViewController.signUpView.logo = signupImageView;
-        
+    }
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+
+    if (![PFUser currentUser]) { // No user logged in    
         [self presentViewController:self.logInViewController animated:YES completion:nil];
     }
     else{


### PR DESCRIPTION
Very small issue, but if you look closely you'll notice the main Parse login screen has the dismiss button on it. This is due to the login fields actually not having customized and the controller falling back to it's default settings. To customize the controller you need to do it before the view loads. Therefore, I just threw almost everything regarding the loginViewController instantiation in viewWillAppear. Now the dismiss button is gone. If you wanted to add Facebook login down the road this will allow that, too.